### PR TITLE
Create a github action to keep repo up-to-date.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '0 0 1 * *' # Run every month
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          owner: pglevy
+          head: main
+          base: master


### PR DESCRIPTION
Sandbox doesn't update often, but if it were more active it might worth trying this github action to sync them. Check notes below, I think we're only missing a token in [secrets](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository)

I haven't used github actions before, just a heads up

---

Runs every month to keep the  repo up-to-date with upstream.

We need to generate a token for this repo. See:
https://github.com/marketplace/actions/fork-sync